### PR TITLE
Add basic structure for adding type generators.

### DIFF
--- a/lib/stream_data/types.ex
+++ b/lib/stream_data/types.ex
@@ -1,0 +1,98 @@
+defmodule StreamData.Types do
+  @doc """
+  Returns any kind of generator by a given type definition.
+  The function takes in a module name, function name and a keyword list
+  of type arguments(defaults to []).
+
+  ## Examples
+
+  Say you have a simple type that is a tuple of an atom and integer,
+  you can use from_type to create a generator out of it.
+
+    defmodule MyModule do
+      @type t :: {atom(), integer()}
+    end
+
+    from_type(MyModule, :t) |> Enum.take(3)
+    #=> [{:asdf, 3}, {:aub, -1}, {:fae, 0}]
+
+  ## Shrinking(TODO(njichev))
+  """
+  def from_type(module, name, args \\ [])
+
+  def from_type(module, name, args) when is_atom(module) and is_atom(name) and is_list(args) do
+    type = for x = {^name, _type} <- beam_types(module), do: x
+
+    # pick correct type, when multiple
+    # Validate outer is list/map/tuple when having args
+    # Convert args
+    # put args in type tuple
+    case type do
+      [] ->
+        msg = """
+        Module #{inspect(module)} does not define a type called #{name}.
+        """
+
+        raise ArgumentError, msg
+
+      types when is_list(types) ->
+        pick_type(types, args)
+        |> do_generate(args)
+    end
+  end
+
+  # Read .beam file to get type information. Raise if the .beam file is not found.
+  defp beam_types(module) do
+    with {^module, beam, _file} <- :code.get_object_code(module),
+         {:ok, {^module, [abstract_code: {:raw_abstract_v1, abstract_code}]}} <-
+           :beam_lib.chunks(beam, [:abstract_code]) do
+      for {:attribute, _line, :type, {name, type, _other}} <- abstract_code, do: {name, type}
+    else
+      _ ->
+        msg = """
+        Could not find .beam file for Module #{inspect(module)}.
+        Are you sure you have passed in the correct module name?
+        """
+
+        raise ArgumentError, msg
+    end
+  end
+
+  # There can be multiple types with different amount of arguments.
+  # Pick the one that matches the amount the user gave as arguments,
+  # otherwise raise an argument error.
+  defp pick_type(types, args) do
+    len = length(args)
+    res = for {_name, t} = type <- types, vars(t) == len, do: type
+
+    case res do
+      [t] ->
+        t
+
+      _ ->
+        raise ArgumentError, "Not enough arguments passed"
+    end
+  end
+
+  # Recursively count the number of variables a type can be given.
+  # Used to choose the correct type for a user.
+  defp vars({:var, _, _}), do: 1
+
+  defp vars({:type, _, _, types}) do
+    vars(types)
+  end
+
+  defp vars(types) when is_list(types) do
+    types
+    |> Enum.map(&vars(&1))
+    |> Enum.sum()
+  end
+
+  defp vars(_), do: 0
+
+  # Handle type generation/recursive/union types here.
+  # Maybe module name should be passed.
+  defp do_generate(type, _args) do
+    type
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule StreamData.Mixfile do
       app: :stream_data,
       version: @version,
       elixir: "~> 1.5",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
 
@@ -47,4 +48,7 @@ defmodule StreamData.Mixfile do
       {:ex_doc, "~> 0.15", only: :dev}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/stream_data/types_list.ex
+++ b/test/stream_data/types_list.ex
@@ -1,0 +1,3 @@
+defmodule StreamDataTest.TypesList do
+  @type basic_atom :: atom()
+end

--- a/test/stream_data/types_test.exs
+++ b/test/stream_data/types_test.exs
@@ -1,0 +1,35 @@
+defmodule StreamData.TypesTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias StreamData.Types
+
+  test "when missing a type" do
+    assert_raise(
+      ArgumentError,
+      "Module StreamDataTest.TypesList does not define a type called does_not_exist.\n",
+      fn -> generate_data(:does_not_exist) end
+    )
+  end
+
+  test "when missing a module" do
+    assert_raise(
+      ArgumentError,
+      """
+      Could not find .beam file for Module DoesNotExist.
+      Are you sure you have passed in the correct module name?
+      """,
+      fn ->
+        Types.from_type(DoesNotExist, :some_type)
+      end
+    )
+  end
+
+  test "a type is returned" do
+    assert {:basic_atom, {:type, _line, :atom, []}} = generate_data(:basic_atom)
+  end
+
+  defp generate_data(name, args \\ []) do
+    Types.from_type(StreamDataTest.TypesList, name, args)
+  end
+end


### PR DESCRIPTION
This includes reading the type from the .beam file, reporting any
missing modules or type definitions and making sure that we get the
type. Also added some small documentation for `from_type`.

Used :code erlang library for this and pattern matching for this.